### PR TITLE
Compatibility with Frida 16.0.9 and iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,10 @@ mutation certainly has lots of room for improvement.
   writes the payload to stdin and receives the mutated payload from stdout. Due to its shallow
   implementation it has quite a performance impact.
 
+### USB devices
+
+Using the `-D usb` device option, Frida will pick the first local USB device, e.g. an iPhone or Android phone.
+
 ### Network devices
 With option `-D remote` it is possible to fuzz a process running on a network device. For this, the
 remote device must be running `frida-server`. As a sample configuration, use SSH with port
@@ -280,6 +284,16 @@ socket on the local client.
 ```bash
 ssh -N user@network.device -L 127.0.0.1:27042:127.0.0.1:27042
 ```
+
+On an iPhone, one can also use `iproxy` to forward the port from a USB connection.
+This might be especially useful if running Frida on a non-standard port on a non-jailbroken device
+with the Frida gadget. When working with the Frida gadget, the only available process will have the
+name `Gadget`, regardless of the target app name.
+
+```bash
+iproxy 27042 27042
+```
+
 Then use `frida-ps` to validate the configuration by listing processes on the remote device:
 ```bash
 frida-ps -R

--- a/README.md
+++ b/README.md
@@ -21,10 +21,24 @@ my employer ([ERNW](https://ernw.de)).
 Required for running fpicker:
 - [frida_compile](https://github.com/frida/frida-compile) to compile the harness script into one JS file
 - The `frida-core-devkit` for the respective platform found at [Frida releases on GitHub](https://github.com/frida/frida/releases).
-    - Depending on the platform you want to target store the library as `frida-core-ios.a`, `frida-core-macos.a`, or `frida-core-linux.a`.
+    - Depending on the platform you want to target store the library as `libfrida-core-ios.a`, `libfrida-core-macos.a`, or `libfrida-core-linux.a`.
     - The same goes for the header files (`frida-core.h`). Store them as `frida-core-linux.h` or `frida-core-ios.h` depending on the platform.
     - The makefile was built this way so you can build for different systems on the same system (usually this is for building on macOS, where
       you can compile for both iOS and macOs). (There is probably a better way do to this?)
+
+    For example, run the following commands:
+    ```
+    cd fpicker
+    wget https://github.com/frida/frida/releases/[yourversion].tar.xz
+    unxz *tar.xz
+    mkdir frida-devkit
+    cd frida-devkit
+    tar -xzf ../*tar
+    cd ..
+    cp frida-devkit/libfrida-core.a libfrida-core-[youros].a
+    cp frida-devkit/frida-core.h frida-core-[youros].h
+    ```
+    Afterwards, `make fpicker-[youros]` should succeed.
 
 Required only when running in AFL++ mode:
 - [AFL++](https://github.com/AFLplusplus/AFLplusplus/)

--- a/examples/protocol_example/test-fuzzer.js
+++ b/examples/protocol_example/test-fuzzer.js
@@ -1,5 +1,5 @@
 // Import the fuzzer base class
-const Fuzzer = require("../../harness/fuzzer.js");
+import { Fuzzer } from "../../harness/fuzzer.js";
 
 // The custom fuzzer needs to subclass the Fuzzer class to work properly
 class TestFuzzer extends Fuzzer.Fuzzer {
@@ -52,4 +52,4 @@ class TestFuzzer extends Fuzzer.Fuzzer {
 }
 
 const f = new TestFuzzer();
-exports.fuzzer = f;
+rpc.exports.fuzzer = f;

--- a/examples/test-network/test-network-fuzzer.js
+++ b/examples/test-network/test-network-fuzzer.js
@@ -1,5 +1,5 @@
 // Import the fuzzer base class
-const Fuzzer = require("../../harness/fuzzer.js");
+import { Fuzzer } from "../../harness/fuzzer.js";
 
 // The custom fuzzer needs to subclass the Fuzzer class to work properly
 class TestFuzzer extends Fuzzer.Fuzzer {
@@ -49,4 +49,4 @@ class TestFuzzer extends Fuzzer.Fuzzer {
 }
 
 const f = new TestFuzzer();
-exports.fuzzer = f;
+rpc.exports.fuzzer = f;

--- a/examples/test/test-fuzzer.js
+++ b/examples/test/test-fuzzer.js
@@ -1,5 +1,5 @@
 // Import the fuzzer base class
-const Fuzzer = require("../../harness/fuzzer.js");
+import { Fuzzer } from "../../harness/fuzzer.js";
 
 // The custom fuzzer needs to subclass the Fuzzer class to work properly
 class TestFuzzer extends Fuzzer.Fuzzer {
@@ -41,4 +41,4 @@ class TestFuzzer extends Fuzzer.Fuzzer {
 }
 
 const f = new TestFuzzer();
-exports.fuzzer = f;
+rpc.exports.fuzzer = f;

--- a/fpicker.c
+++ b/fpicker.c
@@ -417,11 +417,12 @@ FridaSession *spawn_or_attach(fuzzer_state_t *fstate) {
         plog("[*] Spawned %s with PID %d\n", config->process_name, target_pid);
     } else {
         if (config->process_name != NULL) {
-            plog("[*] Trying to attach to process %s\n", config->process_name);
+            plog("[*] Trying to attach to process with name %s.\n", config->process_name);
             // This loop is mainly for afl-cmin as the attached binary often seems to
             // crash when afl-showmap is run. When it's a daemon like bluetoothd, it
             // will take a while to restart so we just wait here.
             for (int retry = 0; retry <= 5 && target_pid == 0; retry++) {
+                // FIXME if the frida port for remote device is not forwarded, this just segfaults
                 FridaProcessList *proc_list = frida_device_enumerate_processes_sync(device, NULL, NULL, &error);
                 for (int i = 0; i < frida_process_list_size(proc_list) && target_pid == 0; i++) {
                     FridaProcess *proc = frida_process_list_get(proc_list, i);
@@ -573,6 +574,7 @@ int main(int argc, char **argv) {
         desired_type = FRIDA_DEVICE_TYPE_USB;
     } else if (fstate->config->device == DEVICE_REMOTE) {
         desired_type = FRIDA_DEVICE_TYPE_REMOTE;
+        plog("[*] Set remote device. Ensure the port 27042 is forwarded!\n"); // FIXME warning as long as this doesn't work
     }
     for (int i = 0; i < num_devices && device == NULL; i++) {
         FridaDevice *dev = frida_device_list_get(devices, i);

--- a/harness/darwin-shm.js
+++ b/harness/darwin-shm.js
@@ -1,4 +1,4 @@
-module.exports = new CModule(`
+export const darwin_shm = new CModule(`
   #define PROT_READ       0x01
   #define PROT_WRITE      0x02
   #define MAP_SHARED      0x0001

--- a/harness/stalker-instrumentation.js
+++ b/harness/stalker-instrumentation.js
@@ -10,7 +10,7 @@ if (Process.arch == "x64") {
   console.log("[!] Unknown architecture!", Process.arch);
 }
 
-module.exports = new CModule(`
+export const stalker_instrumentation = new CModule(`
   #include <gum/gumstalker.h>
   #include <stdint.h>
   #include <stdio.h>


### PR DESCRIPTION
Did some tests and got fpicker running in standalone mode with radamsa as generator. Haven't tested AFL++ yet.

Setting a high queue capacity is generally good to keep many basic blocks in the queue, however, in this particular case it was too high. When calling `Stalker.follow` the whole process would just hang.

Moreover, there was some false crash detection when radamsa sends lengthy messages. I'm not sure if this is something in fpicker itself or an issue in Frida's `message-dispatcher.js`. Either way, fpicker shows a lot of false positive crashes due to this (also see https://github.com/frida/frida-gum/issues/620), and I added code to ignore these crashes.

Also, since Frida 15, one must work with `import` instead of `require` inside `frida-compile`d JavaScript.

After these changes, fpicker runs on my iPhone SE2020 and iPhone 7, currently both on iOS 14.8.