### PR TITLE
Fix for Issue #26

### DIFF
--- a/fpicker.c
+++ b/fpicker.c
@@ -10,6 +10,9 @@
 // is consumed by AFL.
 bool log_to_syslog = false;
 
+// Global variable indicating whether verbose mode is set.
+bool verbose = false;
+
 struct timeval *_start_measure() {
     struct timeval *t = malloc(sizeof(struct timeval));
     gettimeofday(t, NULL);

--- a/fpicker.h
+++ b/fpicker.h
@@ -242,5 +242,5 @@ void create_communication_map(fuzzer_state_t *fstate);
 void harness_prepare(fuzzer_state_t *fstate);
 void _system_cmd(char *command, bool should_log);
 
-bool verbose;
+extern bool verbose;
 #define plog_debug(fmt, args...) if(verbose) plog(fmt, ##args);


### PR DESCRIPTION
This addresses issue #26, global variable 'verbose' declared in a header file