### PR TITLE
Update aflpp-ios.patch

### DIFF
--- a/aflpp-ios.patch
+++ b/aflpp-ios.patch
@@ -1,26 +1,45 @@
 diff --git a/src/afl-fuzz-init.c b/src/afl-fuzz-init.c
-index 3dbc4c65..30676383 100644
+index af6e6d4c..e4492a50 100644
 --- a/src/afl-fuzz-init.c
 +++ b/src/afl-fuzz-init.c
-@@ -2069,7 +2069,7 @@ void setup_stdio_file(afl_state_t *afl) {
- 
+@@ -2412,7 +2412,7 @@ void setup_stdio_file(afl_state_t *afl) {
    unlink(afl->fsrv.out_file);                              /* Ignore errors */
  
--  afl->fsrv.out_fd = open(afl->fsrv.out_file, O_RDWR | O_CREAT | O_EXCL, 0600);
-+  afl->fsrv.out_fd = open(afl->fsrv.out_file, O_RDWR | O_CREAT | O_EXCL, 0666);
+   afl->fsrv.out_fd =
+-      open(afl->fsrv.out_file, O_RDWR | O_CREAT | O_EXCL, DEFAULT_PERMISSION);
++      open(afl->fsrv.out_file, O_RDWR | O_CREAT | O_EXCL, 0666);
  
    if (afl->fsrv.out_fd < 0) {
  
+@@ -3262,4 +3262,3 @@ void save_cmdline(afl_state_t *afl, u32 argc, char **argv) {
+   *buf = 0;
+ 
+ }
+-
 diff --git a/src/afl-sharedmem.c b/src/afl-sharedmem.c
-index 3241a130..f40b3cdc 100644
+index 1dea83f9..e09cfac2 100644
 --- a/src/afl-sharedmem.c
 +++ b/src/afl-sharedmem.c
-@@ -163,7 +163,7 @@ u8 *afl_shm_init(sharedmem_t *shm, size_t map_size,
+@@ -180,7 +180,7 @@ u8 *afl_shm_init(sharedmem_t *shm, size_t map_size,
  
-   /* create the shared memory segment as if it was a file */
-   shm->g_shm_fd =
--      shm_open(shm->g_shm_file_path, O_CREAT | O_RDWR | O_EXCL, 0600);
-+      shm_open(shm->g_shm_file_path, O_CREAT | O_RDWR | O_EXCL, 0666);
-   if (shm->g_shm_fd == -1) { PFATAL("shm_open() failed"); }
+       shm->g_shm_fd =
+           shm_create_largepage(shm->g_shm_file_path, shmflags, i,
+-                               SHM_LARGEPAGE_ALLOC_DEFAULT, DEFAULT_PERMISSION);
++                               SHM_LARGEPAGE_ALLOC_DEFAULT, 0666);
  
-   /* configure the size of the shared memory segment */
+     }
+ 
+@@ -192,7 +192,7 @@ u8 *afl_shm_init(sharedmem_t *shm, size_t map_size,
+   if (shm->g_shm_fd == -1) {
+ 
+     shm->g_shm_fd =
+-        shm_open(shm->g_shm_file_path, shmflags | O_CREAT, DEFAULT_PERMISSION);
++        shm_open(shm->g_shm_file_path, shmflags | O_CREAT, 0666);
+ 
+   }
+ 
+@@ -364,4 +364,3 @@ u8 *afl_shm_init(sharedmem_t *shm, size_t map_size,
+   return shm->map;
+ 
+ }
+-


### PR DESCRIPTION
This pull request updates `aflpp-ios.patch` to reflect changes introduced since AFL++ 3.12a (dev). This makes the patch compatible with the current AFL++ release.

However, I have not yet tested whether fpicker works with the current AFL++ release. 

As with the previous patch, the following file permission updates are applied:

* [`src/afl-fuzz-init.c`](diffhunk://#diff-92b4bc15941a87d36cd186a0ac3573cec6780e0141fd9727a1200f2ff51e786dL2-R45): Changed the file permission mode from `DEFAULT_PERMISSION` to `0666` when opening `afl->fsrv.out_file`.
* [`src/afl-sharedmem.c`](diffhunk://#diff-92b4bc15941a87d36cd186a0ac3573cec6780e0141fd9727a1200f2ff51e786dL2-R45): Updated the file permission mode from `DEFAULT_PERMISSION` to `0666` when opening `shm->g_shm_file_path`.