### PR TITLE
Automate setup and cleanup workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ libfrida-core.a
 libfrida-core-ios.a
 libfrida-core-macos.a
 libfrida-core-linux.a
+frida-devkit-*
 
 node_modules
 package.json

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,30 @@
+.PHONY: setup-devkit clean fpicker-macos fpicker-linux fpicker-ios
+
+OS ?= unknown
+ARCH ?= $(shell uname -m)
+CC ?= clang
+FRAMEWORKS =
+CFLAGS = -fPIC -ffunction-sections -fdata-sections -Wall -Os -pipe -g3
+LDFLAGS = -L. -lfrida-core -ldl -lm -lresolv -pthread
+
 ifeq ($(MAKECMDGOALS), fpicker-macos)
   OS = macos
-  ARCH ?= $(shell uname -m)
   CC = xcrun -r clang
   FRAMEWORKS = -framework Foundation -framework CoreGraphics -framework AppKit -framework IOKit -framework Security
+  LDFLAGS += -lbsm
 endif
 
 ifeq ($(MAKECMDGOALS), fpicker-linux)
   OS = linux
-  ARCH ?= $(shell uname -m)
+  LDFLAGS += -lrt -Wl,--export-dynamic -Wl,--gc-sections,-z,noexecstack
 endif
 
 ifeq ($(MAKECMDGOALS), fpicker-ios)
   OS = ios
-  ARCH ?= arm64
+  ARCH = arm64
   CC = xcrun -sdk iphoneos -r clang
   FRAMEWORKS = -framework Foundation -framework CoreGraphics -framework UIKit -framework IOKit -framework Security
+  LDFLAGS += -arch $(ARCH)
 endif
 
 FRIDA_VERSION = 16.5.9
@@ -28,6 +38,13 @@ $(DEVKIT_FILENAME):
 	@if [ ! -f $@ ]; then \
 		echo "Downloading $(DEVKIT_FILENAME)..."; \
 		wget -q $(DEVKIT_URL) -O $@ || curl -L -o $@ $(DEVKIT_URL); \
+		if [ $$? -ne 0 ]; then \
+			echo "Error downloading $(DEVKIT_FILENAME)"; exit 1; \
+		fi; \
+		if [ $$(stat -c%s $@) -lt 1000 ]; then \
+			echo "Error: Downloaded file $(DEVKIT_FILENAME) is too small. Ensure your system is supported by Frida."; \
+			rm -f $@; exit 1; \
+		fi; \
 	else \
 		echo "$(DEVKIT_FILENAME) already exists, skipping download."; \
 	fi
@@ -38,22 +55,22 @@ $(DEVKIT_DIR): $(DEVKIT_FILENAME)
 		echo "Extracting $(DEVKIT_FILENAME) into $(DEVKIT_DIR)..."; \
 		mkdir -p $@; \
 		tar Jxvf $< -C $@; \
+		if [ $$? -ne 0 ]; then \
+			echo "Error extracting $(DEVKIT_FILENAME)"; exit 1; \
+		fi; \
 	else \
 		echo "$(DEVKIT_DIR) already exists, skipping extraction."; \
 	fi
 
 setup-devkit: $(DEVKIT_DIR)
+	@echo "Setting up devkit..."
 	cp $(DEVKIT_DIR)/libfrida-core.a libfrida-core.a
 	cp $(DEVKIT_DIR)/frida-core.h frida-core.h
 
-fpicker-macos: setup-devkit
-	$(CC) -fPIC $(FRAMEWORKS) -ffunction-sections -fdata-sections -Wall -Os -pipe -g3 fpicker.c fp_communication.c fp_standalone_mode.c fp_afl_mode.c -o fpicker -L. -lfrida-core -ldl -lbsm -lm -lresolv -pthread
-
-fpicker-linux: setup-devkit
-	$(CC) -fPIC -m64 -ffunction-sections -fdata-sections -Wall -Wno-format -Os -pipe -g3 fpicker.c fp_communication.c fp_standalone_mode.c fp_afl_mode.c -o fpicker -L. -lfrida-core -ldl -lm -lresolv -lrt -Wl,--export-dynamic -Wl,--gc-sections,-z,noexecstack -pthread
-
-fpicker-ios: setup-devkit
-	$(CC) -fPIC $(FRAMEWORKS) -ffunction-sections -fdata-sections -Wall -Os -pipe -g3 fpicker.c fp_communication.c fp_standalone_mode.c fp_afl_mode.c -o fpicker -L. -arch $(ARCH) -lfrida-core -ldl -lm -lresolv -pthread
+fpicker-macos fpicker-linux fpicker-ios: setup-devkit
+	@echo "Building for $(OS)..."
+	$(CC) $(CFLAGS) $(FRAMEWORKS) fpicker.c fp_communication.c fp_standalone_mode.c fp_afl_mode.c -o fpicker $(LDFLAGS)
 
 clean:
-	rm -rf fpicker fpicker.dSYM frida-devkit-* frida-core-devkit-*.tar.xz libfrida-core.a frida-core.h fpicker-macos fpicker-linux fpicker-ios
+	@echo "Cleaning up..."
+	rm -rf fpicker fpicker.dSYM frida-devkit-* frida-core-devkit-*.tar.xz libfrida-core.a frida-core.h

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,8 @@ $(DEVKIT_FILENAME):
 		if [ $$? -ne 0 ]; then \
 			echo "Error downloading $(DEVKIT_FILENAME)"; exit 1; \
 		fi; \
-		if [ $$(stat -c%s $@) -lt 1000 ]; then \
+		FILE_SIZE=$$(stat -f%z $@ 2>/dev/null || stat -c%s $@ 2>/dev/null); \
+		if [ $$FILE_SIZE -lt 1000 ]; then \
 			echo "Error: Downloaded file $(DEVKIT_FILENAME) is too small. Ensure your system is supported by Frida."; \
 			rm -f $@; exit 1; \
 		fi; \

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,59 @@
-FRAMEWORKS_MACOS = -framework Foundation -framework CoreGraphics -framework AppKit -framework IOKit -framework Security
-FRAMEWORKS_iOS = -framework Foundation -framework CoreGraphics -framework UIKit -framework IOKit -framework Security
+ifeq ($(MAKECMDGOALS), fpicker-macos)
+  OS = macos
+  ARCH ?= $(shell uname -m)
+  CC = xcrun -r clang
+  FRAMEWORKS = -framework Foundation -framework CoreGraphics -framework AppKit -framework IOKit -framework Security
+endif
 
-CC_MACOS = xcrun -r clang
-CC_iOS = xcrun -sdk iphoneos -r clang
+ifeq ($(MAKECMDGOALS), fpicker-linux)
+  OS = linux
+  ARCH ?= $(shell uname -m)
+endif
 
-fpicker-macos:
-	$(CC_MACOS) -fPIC $(FRAMEWORKS_MACOS) -ffunction-sections -fdata-sections -Wall -Os -pipe -g3 fpicker.c fp_communication.c fp_standalone_mode.c fp_afl_mode.c -o fpicker -L. -lfrida-core-macos -ldl -lbsm -lm -lresolv -pthread
+ifeq ($(MAKECMDGOALS), fpicker-ios)
+  OS = ios
+  ARCH ?= arm64
+  CC = xcrun -sdk iphoneos -r clang
+  FRAMEWORKS = -framework Foundation -framework CoreGraphics -framework UIKit -framework IOKit -framework Security
+endif
 
-fpicker-linux:
-	$(CC) -fPIC -m64 -ffunction-sections -fdata-sections -Wall -Wno-format -Os -pipe -g3 fpicker.c fp_communication.c fp_standalone_mode.c fp_afl_mode.c -o fpicker -L. -lfrida-core-linux -ldl -lm -lresolv -lrt -Wl,--export-dynamic -Wl,--gc-sections,-z,noexecstack -pthread
+FRIDA_VERSION = 16.5.9
+BASE_URL = https://github.com/frida/frida/releases/download/$(FRIDA_VERSION)
+DEVKIT_FILENAME = frida-core-devkit-$(FRIDA_VERSION)-$(OS)-$(ARCH).tar.xz
+DEVKIT_URL = $(BASE_URL)/$(DEVKIT_FILENAME)
+DEVKIT_DIR = frida-devkit-$(OS)-$(ARCH)
 
-fpicker-ios:
-	$(CC_iOS) -fPIC $(FRAMEWORKS_iOS) -ffunction-sections -fdata-sections -Wall -Os -pipe -g3 fpicker.c fp_communication.c fp_standalone_mode.c fp_afl_mode.c -o fpicker -L. -arch arm64 -lfrida-core-ios -ldl -lm -lresolv -pthread
+$(DEVKIT_FILENAME):
+	@echo "Checking for devkit tarball..."
+	@if [ ! -f $@ ]; then \
+		echo "Downloading $(DEVKIT_FILENAME)..."; \
+		wget -q $(DEVKIT_URL) -O $@ || curl -L -o $@ $(DEVKIT_URL); \
+	else \
+		echo "$(DEVKIT_FILENAME) already exists, skipping download."; \
+	fi
 
+$(DEVKIT_DIR): $(DEVKIT_FILENAME)
+	@echo "Checking for extracted devkit..."
+	@if [ ! -d $@ ]; then \
+		echo "Extracting $(DEVKIT_FILENAME) into $(DEVKIT_DIR)..."; \
+		mkdir -p $@; \
+		tar Jxvf $< -C $@; \
+	else \
+		echo "$(DEVKIT_DIR) already exists, skipping extraction."; \
+	fi
+
+setup-devkit: $(DEVKIT_DIR)
+	cp $(DEVKIT_DIR)/libfrida-core.a libfrida-core.a
+	cp $(DEVKIT_DIR)/frida-core.h frida-core.h
+
+fpicker-macos: setup-devkit
+	$(CC) -fPIC $(FRAMEWORKS) -ffunction-sections -fdata-sections -Wall -Os -pipe -g3 fpicker.c fp_communication.c fp_standalone_mode.c fp_afl_mode.c -o fpicker -L. -lfrida-core -ldl -lbsm -lm -lresolv -pthread
+
+fpicker-linux: setup-devkit
+	$(CC) -fPIC -m64 -ffunction-sections -fdata-sections -Wall -Wno-format -Os -pipe -g3 fpicker.c fp_communication.c fp_standalone_mode.c fp_afl_mode.c -o fpicker -L. -lfrida-core -ldl -lm -lresolv -lrt -Wl,--export-dynamic -Wl,--gc-sections,-z,noexecstack -pthread
+
+fpicker-ios: setup-devkit
+	$(CC) -fPIC $(FRAMEWORKS) -ffunction-sections -fdata-sections -Wall -Os -pipe -g3 fpicker.c fp_communication.c fp_standalone_mode.c fp_afl_mode.c -o fpicker -L. -arch $(ARCH) -lfrida-core -ldl -lm -lresolv -pthread
+
+clean:
+	rm -rf fpicker fpicker.dSYM frida-devkit-* frida-core-devkit-*.tar.xz libfrida-core.a frida-core.h fpicker-macos fpicker-linux fpicker-ios

--- a/README.md
+++ b/README.md
@@ -21,24 +21,8 @@ my employer ([ERNW](https://ernw.de)).
 Required for running fpicker:
 - [frida_compile](https://github.com/frida/frida-compile) to compile the harness script into one JS file
 - The `frida-core-devkit` for the respective platform found at [Frida releases on GitHub](https://github.com/frida/frida/releases).
-    - Depending on the platform you want to target store the library as `libfrida-core-ios.a`, `libfrida-core-macos.a`, or `libfrida-core-linux.a`.
-    - The same goes for the header files (`frida-core.h`). Store them as `frida-core-linux.h` or `frida-core-ios.h` depending on the platform.
-    - The makefile was built this way so you can build for different systems on the same system (usually this is for building on macOS, where
-      you can compile for both iOS and macOs). (There is probably a better way do to this?)
-
-    For example, run the following commands:
-    ```
-    cd fpicker
-    wget https://github.com/frida/frida/releases/[yourversion].tar.xz
-    unxz *tar.xz
-    mkdir frida-devkit
-    cd frida-devkit
-    tar -xzf ../*tar
-    cd ..
-    cp frida-devkit/libfrida-core.a libfrida-core-[youros].a
-    cp frida-devkit/frida-core.h frida-core-[youros].h
-    ```
-    Afterwards, `make fpicker-[youros]` should succeed.
+    - If you prefer to use a specific version, adjust the Makefile accordingly.
+    - To update to the latest version, simply run `update_frida_version.sh` before building.
 
 Required only when running in AFL++ mode:
 - [AFL++](https://github.com/AFLplusplus/AFLplusplus/)

--- a/fpicker.h
+++ b/fpicker.h
@@ -1,8 +1,4 @@
-#ifdef __linux__
-    #include "frida-core-linux.h"
-#else
-    #include "frida-core.h"
-#endif
+#include "frida-core.h"
 
 #include <syslog.h>
 #include <stdint.h>

--- a/update_frida_version.sh
+++ b/update_frida_version.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+test -n "$1" && { echo This script has no options. It updates the referenced Frida version in makefile to the most current one. ; exit 1 ; }
+
+OLD=$(grep -E '^FRIDA_VERSION\s*=' Makefile 2>/dev/null | awk -F= '{print $2}' | tr -d '[:space:]')
+NEW=$(curl https://github.com/frida/frida/releases/ 2>/dev/null|grep 'Frida\ [0-9.]*'|head -n 1|sed 's/.*Frida\ //'| sed 's/<\/h2>//')
+
+echo Current set version: $OLD
+echo Newest available version: $NEW
+
+test -z "$OLD" -o -z "$NEW" -o "$OLD" = "$NEW" && { echo Nothing to be done. ; exit 0 ; }
+
+# Determine the correct sed command
+case $(sed --help 2>&1) in
+  *GNU*) set sed -i;;
+  *) set sed -i '';;
+esac
+
+"$@" "s/=\ $OLD/=\ $NEW/" Makefile || exit 1
+echo Successfully updated Makefile


### PR DESCRIPTION
- Added logic to automatically download and extract the frida-core-devkit.
- Implemented a cleanup mechanism to remove old build files and devkit tarballs.
- Included a new script to update the Frida version in the Makefile to the latest release.