### PR TITLE
Update module parsing (standalone mode)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ ifeq ($(MAKECMDGOALS), fpicker-ios)
   LDFLAGS += -arch $(ARCH)
 endif
 
-FRIDA_VERSION = 16.5.9
+FRIDA_VERSION = 16.6.6
 BASE_URL = https://github.com/frida/frida/releases/download/$(FRIDA_VERSION)
 DEVKIT_FILENAME = frida-core-devkit-$(FRIDA_VERSION)-$(OS)-$(ARCH).tar.xz
 DEVKIT_URL = $(BASE_URL)/$(DEVKIT_FILENAME)


### PR DESCRIPTION
This pull request includes changes to parsing in the `fp_standalone_mode.c` file. 

Improvements to `fp_standalone_mode.c`:

* Recent versions of Frida (16.3 and possibly earlier) no longer return the `module.end` field. To address this, the `stdln_parse_modules_from_json` function has been updated to calculate the module’s end address using the `size` field instead.

Updates to `Makefile`:

* Bumped `FRIDA_VERSION` from `16.5.9` to `16.6.6`.